### PR TITLE
ERP-1: Implement generic response type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exchange-rates-as-promised",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exchange-rates-as-promised",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "A promised based exchange rates API client which provides easy to use functions for exchanging currencies",

--- a/src/ExchangeRate.ts
+++ b/src/ExchangeRate.ts
@@ -3,6 +3,7 @@ import { Currencies } from './enums/Currencies'
 import { ExchangeResponse } from './types/ExchangeResponse'
 
 import Axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { RatesMapper } from './lib/RatesMapper'
 
 /**
  * ExchangeRate class used to query the Exchange Rates API
@@ -94,7 +95,11 @@ class ExchangeRate {
     /**
      * Format response from API into appropriately typed response
      */
-    const formatResponse = (response: AxiosResponse): ExchangeResponse => response.data as ExchangeResponse
+    const formatResponse = ({ data }: AxiosResponse): ExchangeResponse => ({
+      rates: RatesMapper.remapRatesResponse(data),
+      date: data.date,
+      base: data.base
+    })
 
     /**
      * Tap log error and rethrow the error

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Rates } from './types/Rates'
 import { Queries } from './types/Queries'
 import { ExchangeRate } from './ExchangeRate'
 import { Currencies } from './enums/Currencies'
+import { ExchangeRates } from './types/ExchangeRates'
 import { HistoricalRates } from './types/HistoricalRates'
 import { ExchangeResponse } from './types/ExchangeResponse'
 
@@ -10,6 +11,7 @@ export {
   Queries,
   Currencies,
   ExchangeRate,
+  ExchangeRates,
   HistoricalRates,
   ExchangeResponse
 }

--- a/src/lib/RatesMapper.ts
+++ b/src/lib/RatesMapper.ts
@@ -1,0 +1,66 @@
+import { ExchangeRates, ExchangeResponse, HistoricalRates, Rates } from '..'
+
+class RatesMapper {
+  static remapRatesResponse(data: ExchangeResponse): ExchangeRates {
+    return this.mapHistoricalRates(data.rates as HistoricalRates)
+  }
+
+  private static mapRates(typedData: Rates) {
+    const currencies = Object.keys(typedData)
+
+    const rateToLatest = (currency: string) => {
+      const mappedRate = {
+        latest: typedData[currency]
+      }
+      return [ currency, mappedRate ]
+    }
+
+    const mappedCurrencies = currencies.map(rateToLatest)
+    return Object.fromEntries(mappedCurrencies)
+  }
+
+  /**
+   * Map historical rates into a user-friendly format
+   */
+  private static mapHistoricalRates(typedData: HistoricalRates) {
+    // Get the dates from the rates
+    const dates = Object.keys(typedData)
+
+    /**
+     * Determines the latest datestamp returned in the response
+     */
+    const toLatestDatestamp = (acc: string, date: string) => {
+      if (acc < date) {
+        return date
+      }
+      return acc
+    }
+
+    /**
+     * Map the currencies to the appropriate symbol designation
+     */
+    const currencyToSymbol = (symbol: string) => {
+      // Map the dates with the appropriate set of rates
+      const datedArrays = dates.map((date: string) => {
+        return [ [ date ], typedData.rates[date][symbol] ]
+      })
+
+      // Create an object with the appropriate mapped currency and rates
+      return [ [ symbol ], Object.fromEntries(datedArrays) ]
+    }
+
+    // Get the latest datestamp from the response
+    const latestDate = dates.reduce(toLatestDatestamp)
+
+    // Determine the symbols from the response
+    const symbols = Object.keys(typedData[latestDate])
+
+    // Map the rates into designated format
+    const mappedRatesData = symbols.map(currencyToSymbol)
+
+    // Create the response object using the mapped rates
+    return Object.fromEntries(mappedRatesData)
+  }
+}
+
+export { RatesMapper }

--- a/src/types/ExchangeRates.ts
+++ b/src/types/ExchangeRates.ts
@@ -1,0 +1,8 @@
+interface ExchangeRates {
+  [name: string]: {
+    latest: string
+    [name: string]: string
+  }
+}
+
+export { ExchangeRates }

--- a/src/types/ExchangeResponse.ts
+++ b/src/types/ExchangeResponse.ts
@@ -1,4 +1,4 @@
-import { Currencies, HistoricalRates, Rates } from '..'
+import { Currencies, ExchangeRates } from '..'
 
 /**
  * Representation of the response from the Exchange Rates API
@@ -15,7 +15,7 @@ interface ExchangeResponse {
   /**
    * Conversion rates against the base currency
    */
-  rates: HistoricalRates | Rates
+  rates: ExchangeRates
 }
 
 export { ExchangeResponse }

--- a/src/types/HistoricalRates.ts
+++ b/src/types/HistoricalRates.ts
@@ -9,7 +9,7 @@ interface HistoricalRates {
     /**
      * Currency and value
      */
-    [name: string]: number
+    [name: string]: string
   }
 }
 

--- a/src/types/Rates.ts
+++ b/src/types/Rates.ts
@@ -5,7 +5,7 @@ interface Rates {
   /**
    * Currency and value
    */
-  [name: string]: number
+  [name: string]: string
 }
 
 export { Rates }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "strict": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "resolveJsonModule": true,
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "target": "es5",
     "outDir": "dist/",


### PR DESCRIPTION
As it stands, there are two response types depending on the request the user makes. If historical data is requested, then the response conforms to the `HistoricalDate` type whereas any other request conforms to the `Rates` type.

These responses should be remapped to create a single simplified model to conform to. This will make working with the response easier as no type checks will need to be performed prior to manipulating the response object.

**Acceptance Criteria**
**Given** user of the client,
**When** a request for historical data is made,
**Then** a response that conforms to a generic model is returned.

**Given** user of the client,
**When** a request for an exchange rate is made,
**Then** a response that conforms to a generic model is returned.

[Trello Board Here](https://trello.com/c/yIwons7z)